### PR TITLE
Ignore reserved units for av1 decoder

### DIFF
--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
@@ -96,6 +96,7 @@ namespace UMC_AV1_DECODER
 
     enum AV1_OBU_TYPE
     {
+	OBU_Reserved = 0,
         OBU_SEQUENCE_HEADER = 1,
         OBU_TEMPORAL_DELIMITER = 2,
         OBU_FRAME_HEADER = 3,

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
@@ -1191,7 +1191,8 @@ namespace UMC_AV1_DECODER
 
         if (info.header.obu_has_size_field)
             av1_read_obu_size(*this, obu_size, sizeFieldLength);
-        else if (info.header.obu_type != OBU_TEMPORAL_DELIMITER)
+	// Av1-spec section 6.2.2: Reserved units are for future use and shall be ignored by AV1 decoder.
+        else if (info.header.obu_type != OBU_TEMPORAL_DELIMITER && info.header.obu_type != OBU_Reserved)
             throw av1_exception(UMC::UMC_ERR_NOT_IMPLEMENTED); // no support for OBUs w/o size field so far
 
         info.size = headerSize + sizeFieldLength + obu_size;


### PR DESCRIPTION
case:android.mediav2.cts.AdaptivePlaybackTest#testAdaptivePlayback

Some av1 videos may contain reserved units. We should ignore it instead of returning an error.

Reference source:
https://aomediacodec.github.io/av1-spec/av1-spec.pdf
Section 6.2.6: Reserved units are for future use and shall be ignored by AV1 decoder.

Tracked-On: OAM-102526
Signed-off-by: zhangyichix <yichix.zhang@intel.com>