### PR TITLE
Add Android T definitions for onevpl-intel-gpu

### DIFF
--- a/android/include/mfx_android_config.h
+++ b/android/include/mfx_android_config.h
@@ -18,5 +18,6 @@ Copyright(c) 2011-2018 Intel Corporation. All Rights Reserved.
 #define MFX_Q     0x09
 #define MFX_R     0x0b
 #define MFX_S     0x0c
+#define MFX_T     0x0d
 
 #endif // #ifndef __MFX_CONFIG_H__

--- a/android/mfx_defs.mk
+++ b/android/mfx_defs.mk
@@ -21,6 +21,9 @@ MEDIA_VERSION_ALL := $(MEDIA_VERSION).pre$(MEDIA_VERSION_EXTRA)
 MFX_CFLAGS += -DMEDIA_VERSION_STR=\"\\\"${MEDIA_VERSION_ALL}\\\"\"
 
 # Android version preference:
+ifneq ($(filter 13 13.% T% ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_T
+endif
 ifneq ($(filter 12 12.% S ,$(PLATFORM_VERSION)),)
   MFX_ANDROID_VERSION:= MFX_S
 endif


### PR DESCRIPTION
PLATFORM_VERSION for Android 13 is "Tiramisu".

Tracked-On: OAM-103588
Signed-off-by: svenate <salini.venate@intel.com>