### PR TITLE
When the max_frame_size is changed in sequence header, Return resolut…

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -892,6 +892,8 @@ mfxStatus VideoDECODEAV1::SubmitFrame(mfxBitstream* bs, mfxFrameSurface1* surfac
             UMC::Status umcRes = m_surface_source->HasFreeSurface() ?
                 m_decoder->GetFrame(bs ? &src : 0, nullptr) : UMC::UMC_ERR_NEED_FORCE_OUTPUT;
 
+            MFX_CHECK(umcRes != UMC::UMC_NTF_NEW_RESOLUTION, MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+
             UMC::Status umcFrameRes = umcRes;
 
              if (umcRes == UMC::UMC_NTF_NEW_RESOLUTION ||


### PR DESCRIPTION
…ionChanged.

Check max_frame_size in parsing sequence header. When the size is larger than previous value. Return resolutionChanged.

Tracked-On: OAM-105186
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>