### PR TITLE
[Decode] Support multiple av1 sequence headers case (#1546)

### DIFF
--- a/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
+++ b/_studio/mfx_lib/decode/av1/src/mfx_av1_dec_decode.cpp
@@ -904,6 +904,11 @@ mfxStatus VideoDECODEAV1::SubmitFrame(mfxBitstream* bs, mfxFrameSurface1* surfac
                  m_video_par.AsyncDepth = static_cast<mfxU16>(vp.async_depth);
             }
 
+            if (umcFrameRes == UMC::UMC_NTF_NEW_RESOLUTION)
+            {
+                MFX_RETURN(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM);
+            }
+
             if (umcRes == UMC::UMC_ERR_INVALID_STREAM)
             {
                 umcRes = UMC::UMC_OK;

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_decoder.cpp
@@ -82,6 +82,33 @@ namespace UMC_AV1_DECODER
             return MFX_LEVEL_UNKNOWN;
     }
 
+    static bool IsNeedSPSInvalidate(const SequenceHeader *old_sps, const SequenceHeader *new_sps)
+    {
+        if (!old_sps || !new_sps)
+        {
+            return false;
+        }
+
+        if ((old_sps->max_frame_width != new_sps->max_frame_width) ||
+            (old_sps->max_frame_height != new_sps->max_frame_height))
+        {
+            return true;
+        }
+
+        if (old_sps->seq_profile != new_sps->seq_profile)
+        {
+            return true;
+        }
+
+        if ((old_sps->frame_height_bits != new_sps->frame_height_bits) ||
+            (old_sps->frame_width_bits != new_sps->frame_width_bits))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     UMC::Status AV1Decoder::DecodeHeader(UMC::MediaData* in, UMC_AV1_DECODER::AV1DecoderParams& par)
     {
         if (!in)
@@ -467,11 +494,25 @@ namespace UMC_AV1_DECODER
                 switch (obuType)
                 {
                 case OBU_SEQUENCE_HEADER:
-                    if (!sequence_header.get())
+                {   if (!sequence_header.get())
                         sequence_header.reset(new SequenceHeader);
                     *sequence_header = SequenceHeader{};
                     bs.ReadSequenceHeader(*sequence_header);
+
+                    SequenceHeader const *old_seqHdr = nullptr;
+                    if (pPrevFrame)
+                    {
+                        old_seqHdr= &pPrevFrame->GetSeqHeader();
+                    }
+
+                    // check if sequence header has been changed
+                    if (IsNeedSPSInvalidate(old_seqHdr, sequence_header.get()))
+                    {
+                        // new resolution required
+                        return UMC::UMC_NTF_NEW_RESOLUTION;
+                    }
                     break;
+                }
                 case OBU_FRAME_HEADER:
                 case OBU_REDUNDANT_FRAME_HEADER:
                 case OBU_FRAME:
@@ -792,5 +833,6 @@ namespace UMC_AV1_DECODER
             i != std::end(dpb) ? (*i) : nullptr;
     }
 }
+
 
 #endif //MFX_ENABLE_AV1_VIDEO_DECODE


### PR DESCRIPTION
If there is a new av1 sequence header manually concatenated old one, VPL runtime will return MFX_ERR_INCOMPATIBLE_VIDEO_PARAM to application, then application creates a video device.

Tracked-On: OAM-105186
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
Co-authored-by: Zefu Li <zefu.li@intel.com>