### PR TITLE
Update API to version 2.8

### DIFF
--- a/android/mfx_defs.mk
+++ b/android/mfx_defs.mk
@@ -67,7 +67,7 @@ else ifneq ($(filter MFX_P, $(MFX_ANDROID_VERSION)),)
 else
   MFX_CFLAGS += \
     -DMFX_ENABLE_CPLIB \
-    -DMFX_VERSION=2003
+    -DMFX_VERSION=2008
 endif
 
 MFX_CFLAGS += \


### PR DESCRIPTION
Update API to version 2.8
version 2.8 is needed by using multi-adapter.

Tracked-On: OAM-110480
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>