### PR TITLE
[do-not-merge] enable log on celadon

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,4 @@
+MFX_HOME:= $(call my-dir)
+
+# Recursively call sub-folder Android.mk
+include $(call all-subdir-makefiles)

--- a/_studio/Android.mk
+++ b/_studio/Android.mk
@@ -1,0 +1,3 @@
+# Recursively call sub-folder Android.mk
+
+include $(call all-subdir-makefiles)

--- a/_studio/mfx_lib/Android.mk
+++ b/_studio/mfx_lib/Android.mk
@@ -1,0 +1,339 @@
+
+LOCAL_PATH:= $(MFX_HOME)/_studio
+
+# =============================================================================
+
+MFX_LOCAL_DECODERS := h265 h264 vc1 mjpeg vp8 vp9 av1
+MFX_LOCAL_ENCODERS := h264 mpeg2 mjpeg vp9
+
+# Setting subdirectories to march thru
+MFX_LOCAL_DIRS := \
+    scheduler/linux \
+
+MFX_LOCAL_DIRS_IMPL := \
+    $(addprefix decode/, $(MFX_LOCAL_DECODERS)) \
+    vpp
+
+MFX_LOCAL_DIRS_HW := \
+    $(addprefix encode_hw/, $(MFX_LOCAL_ENCODERS)) \
+    mctf_package/mctf \
+    cmrt_cross_platform
+
+#scheduler/linux/src
+MFX_LOCAL_SRC_FILES := \
+    $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/src/*.cpp)))
+
+#decode/h265 h264 vc1 mjpeg vp8 vp9 av1/src
+MFX_LOCAL_SRC_FILES_IMPL := \
+    $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS_IMPL), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/src/*.cpp)))
+
+#encode_hw/h264 mpeg2 mjpeg vp9/src
+MFX_LOCAL_SRC_FILES_HW := \
+    $(MFX_LOCAL_SRC_FILES_IMPL) \
+    $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS_HW), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/src/*.cpp)))
+
+#mpeg2 hw decoder
+MFX_LOCAL_SRC_FILES_HW += $(addprefix mfx_lib/decode/mpeg2/hw/src/, \
+    mfx_mpeg2_decode.cpp)
+
+MFX_LOCAL_SRC_FILES_HW += $(addprefix mfx_lib/ext/genx/h264_encode/isa/, \
+    genx_simple_me_gen12lp_isa.cpp \
+    genx_histogram_gen12lp_isa.cpp)
+
+MFX_LOCAL_SRC_FILES_HW += \
+    mfx_lib/encode_hw/av1/av1ehw_disp.cpp \
+    mfx_lib/encode_hw/av1/agnostic/av1ehw_base.cpp \
+    mfx_lib/encode_hw/av1/linux/base/av1ehw_base_lin.cpp \
+    mfx_lib/encode_hw/av1/linux/base/av1ehw_base_va_lin.cpp \
+    mfx_lib/encode_hw/av1/linux/base/av1ehw_base_va_packer_lin.cpp \
+    mfx_lib/encode_hw/av1/linux/base/av1ehw_base_max_frame_size_lin.cpp \
+    mfx_lib/encode_hw/av1/agnostic/Xe_HPM/av1ehw_xe_hpm_segmentation.cpp \
+    mfx_lib/encode_hw/av1/linux/Xe_HPM/av1ehw_xe_hpm_lin.cpp \
+    mfx_lib/encode_hw/av1/linux/Xe_LPM_plus/av1ehw_xe_lpm_plus_lin.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_alloc.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_constraints.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_qmatrix.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_general.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_general_defaults.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_impl.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_packer.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_query_impl_desc.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_segmentation.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_task.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_tile.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_encoded_frame_info.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_max_frame_size.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_enctools.cpp \
+    mfx_lib/encode_hw/av1/agnostic/base/av1ehw_base_hdr.cpp \
+
+MFX_LOCAL_SRC_FILES_HW += \
+    mfx_lib/encode_hw/hevc/hevcehw_disp.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/hevcehw_base.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_impl.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_alloc.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_constraints.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_dirty_rect.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_encoded_frame_info.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_encode_stats.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_enctools.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_ext_brc.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_hdr_sei.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_hrd.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_scc.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_interlace.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_max_frame_size.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_packer.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_parser.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_recon_info.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_rext.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_roi.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_task.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_query_impl_desc.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_weighted_prediction.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_interlace_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_dirty_rect_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_max_frame_size_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_roi_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_va_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_rext_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_va_packer_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_qp_modulation_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/base/hevcehw_base_weighted_prediction_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/g12/hevcehw_g12_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/xe_hpm/hevcehw_xe_hpm_lin.cpp \
+    mfx_lib/encode_hw/hevc/linux/xe_lpm_plus/hevcehw_xe_lpm_plus_lin.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_extddi.cpp \
+    mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_caps.cpp \
+    mfx_lib/encode_hw/shared/ehw_resources_pool.cpp \
+    mfx_lib/encode_hw/shared/ehw_task_manager.cpp \
+    mfx_lib/encode_hw/shared/ehw_device_vaapi.cpp \
+    mfx_lib/encode_hw/shared/ehw_utils_vaapi.cpp \
+    mfx_lib/ext/cmrt_cross_platform/src/cm_mem_copy.cpp \
+    mfx_lib/ext/cmrt_cross_platform/src/cmrt_cross_platform.cpp \
+    mfx_lib/ext/cmrt_cross_platform/src/cmrt_utility.cpp \
+    mfx_lib/ext/asc/src/asc_cm.cpp
+
+#scheduler/linux/include
+MFX_LOCAL_INCLUDES := \
+    $(foreach dir, $(MFX_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/include))
+
+#decode/h265 h264 vc1 mjpeg vp8 vp9 av1/include
+MFX_LOCAL_INCLUDES_IMPL := \
+    $(MFX_LOCAL_INCLUDES) \
+    $(foreach dir, $(MFX_LOCAL_DIRS_IMPL), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/include))
+
+#decode/mpeg2/hw/include
+MFX_LOCAL_INCLUDES_IMPL += \
+    $(MFX_HOME)/_studio/mfx_lib/decode/mpeg2/hw/include
+
+#encode_hw/h264 mpeg2 mjpeg vp9/include
+MFX_LOCAL_INCLUDES_IMPL += \
+    $(foreach dir, $(MFX_LOCAL_DIRS_HW), $(wildcard $(LOCAL_PATH)/mfx_lib/$(dir)/include))
+
+MFX_LOCAL_INCLUDES_HW := \
+    $(MFX_LOCAL_INCLUDES_IMPL) \
+    $(MFX_HOME)/_studio/mfx_lib/ext/asc/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/h264_encode/isa \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/field_copy/isa \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/copy_kernels/isa \
+    $(MFX_HOME)/_studio/mfx_lib/ext/cmrt_cross_platform/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/mctf/isa \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/asc/isa \
+    $(MFX_HOME)/_studio/mfx_lib/ext/h264/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/mpeg2/include \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1 \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/agnostic \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/agnostic/base \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/agnostic/Xe_HPM \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/agnostic/Xe_LPM_plus \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/linux \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/linux/base \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/linux/Xe_HPM \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/av1/linux/Xe_LPM_plus \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/agnostic \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/agnostic/base \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/agnostic/g12 \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/base \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/g12 \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/xe_hpm \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/xe_lpm_plus \
+    $(MFX_HOME)/_studio/mfx_lib/encode_hw/shared \
+    $(MFX_HOME)/_studio/mfx_lib/shared/include/feature_blocks \
+    $(MFX_HOME)/_studio/mfx_lib/scheduler/linux/include \
+    $(MFX_HOME)/_studio/shared/asc/include
+
+MFX_LOCAL_STATIC_LIBRARIES_HW := \
+    libmfx_core_hw \
+    libumc_codecs_hw \
+    libumc_brc \
+    libumc_va \
+    libumc_core_hw \
+    libmfx_gen_trace \
+    libmfx_asc \
+    libmfx_logging
+
+MFX_LOCAL_LDFLAGS_HW := \
+    $(MFX_LDFLAGS) \
+    -Wl,--version-script=$(LOCAL_PATH)/mfx_lib/libmfx-gen.map
+
+# =============================================================================
+
+UMC_DIRS := \
+    h264_enc \
+    brc
+
+UMC_DIRS_IMPL := \
+    h265_dec h264_dec mpeg2_dec vc1_dec jpeg_dec vp9_dec av1_dec \
+    vc1_common jpeg_common color_space_converter
+
+UMC_LOCAL_INCLUDES := \
+    $(foreach dir, $(UMC_DIRS), $(wildcard $(MFX_HOME)/_studio/shared/umc/codec/$(dir)/include))
+
+UMC_LOCAL_INCLUDES_IMPL := \
+    $(UMC_LOCAL_INCLUDES) \
+    $(foreach dir, $(UMC_DIRS_IMPL), $(wildcard $(MFX_HOME)/_studio/shared/umc/codec/$(dir)/include))
+
+UMC_LOCAL_INCLUDES_HW := \
+    $(UMC_LOCAL_INCLUDES_IMPL)
+
+# =============================================================================
+
+MFX_SHARED_FILES_IMPL := $(addprefix mfx_lib/shared/src/, \
+    mfx_feature_blocks_base.cpp \
+    mfx_brc_common.cpp \
+    mfx_common_decode_int.cpp \
+    mfx_common_int.cpp \
+    mfx_enc_common.cpp \
+    mfx_log.cpp \
+    mfx_enc_enctools_common.cpp \
+    mfx_mpeg2_dec_common.cpp \
+    mfx_vc1_dec_common.cpp \
+    mfx_ddi_enc_dump.cpp \
+    mfx_vpx_dec_common.cpp)
+
+MFX_SHARED_FILES_HW := \
+    $(MFX_SHARED_FILES_IMPL)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/genx/asc/isa/, \
+    genx_scd_gen12lp_isa.cpp)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/genx/copy_kernels/isa/, \
+    genx_copy_kernel_gen12lp_isa.cpp)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/genx/field_copy/isa/, \
+    genx_fcopy_gen12lp_isa.cpp)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/genx/mctf/isa/, \
+    genx_me_gen12lp_isa.cpp \
+    genx_mc_gen12lp_isa.cpp \
+    genx_sd_gen12lp_isa.cpp)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/mpeg2/src/, \
+    mfx_mpeg2_encode_debug_hw.cpp \
+    mfx_mpeg2_encode_full_hw.cpp \
+    mfx_mpeg2_encode_hw.cpp \
+    mfx_mpeg2_encode_utils_hw.cpp \
+    mfx_mpeg2_encode_vaapi.cpp \
+    mfx_mpeg2_encode_factory.cpp \
+    mfx_mpeg2_enc_common_hw.cpp)
+
+MFX_SHARED_FILES_HW += $(addprefix mfx_lib/ext/h264/src/, \
+    mfx_h264_encode_cm.cpp)
+
+MFX_LIB_SHARED_FILES_1 := $(addprefix mfx_lib/shared/src/, \
+    libmfxsw.cpp \
+    libmfxsw_async.cpp \
+    libmfxsw_decode.cpp \
+    libmfxsw_decode_vp.cpp \
+    libmfxsw_functions.cpp \
+    libmfxsw_enc.cpp \
+    libmfxsw_encode.cpp \
+    libmfxsw_pak.cpp \
+    libmfxsw_plugin.cpp \
+    libmfxsw_query.cpp \
+    libmfxsw_session.cpp \
+    libmfxsw_vpp.cpp \
+    mfx_session.cpp \
+    mfx_critical_error_handler.cpp)
+
+MFX_LIB_SHARED_FILES_2 := $(addprefix shared/src/, \
+    fast_copy.cpp \
+    fast_copy_c_impl.cpp \
+    fast_copy_sse4_impl.cpp \
+    mfx_vpp_vaapi.cpp \
+    mfx_vpp_helper.cpp \
+    libmfx_allocator.cpp \
+    libmfx_allocator_vaapi.cpp \
+    libmfx_core.cpp \
+    libmfx_core_hw.cpp \
+    libmfx_core_factory.cpp \
+    libmfx_core_vaapi.cpp \
+    mfx_umc_alloc_wrapper.cpp \
+    mfx_umc_mjpeg_vpp.cpp)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := \
+    $(MFX_LOCAL_SRC_FILES) \
+    $(MFX_LOCAL_SRC_FILES_HW) \
+    $(MFX_SHARED_FILES_HW)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_LOCAL_INCLUDES_HW) \
+    $(UMC_LOCAL_INCLUDES_HW) \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CPPFLAGS += -std=c++14
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error -Wno-unused-parameter -Wno-implicit-fallthrough
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_core_hw
+LOCAL_SHARED_LIBRARIES := liblog libcutils
+
+include $(BUILD_STATIC_LIBRARY)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(MFX_LIB_SHARED_FILES_1) $(MFX_LIB_SHARED_FILES_2)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_LOCAL_INCLUDES_HW) \
+    $(UMC_LOCAL_INCLUDES_HW) \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error -Wno-unused-parameter -Wno-implicit-fallthrough
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_LDFLAGS := $(MFX_LOCAL_LDFLAGS_HW)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+LOCAL_WHOLE_STATIC_LIBRARIES := $(MFX_LOCAL_STATIC_LIBRARIES_HW)
+LOCAL_SHARED_LIBRARIES := libva liblog libcutils libdrm
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx-gen
+
+include $(BUILD_SHARED_LIBRARY)

--- a/_studio/mfx_lib/ext/h264/src/mfx_h264_encode_cm.cpp
+++ b/_studio/mfx_lib/ext/h264/src/mfx_h264_encode_cm.cpp
@@ -60,7 +60,11 @@ CmProgram * ReadProgram(CmDevice * device, const mfxU8 * buffer, size_t len)
     return program;
 }
 
+#ifdef ANDROID
+CmKernel * CreateKernel(CmDevice * device, CmProgram * program, char const * name, const void * funcptr)
+#else
 CmKernel * CreateKernel(CmDevice * device, CmProgram * program, char const * name, void * funcptr)
+#endif
 {
     int result = CM_SUCCESS;
     CmKernel * kernel = 0;
@@ -870,15 +874,26 @@ void CmContext::Setup(
 
     if (m_program)
     {
+#ifdef ANDROID
+        m_kernelI = CreateKernel(m_device, m_program, "EncMB_I", CM_KERNEL_FUNCTION(EncMB_I));
+        m_kernelP = CreateKernel(m_device, m_program, "EncMB_P", CM_KERNEL_FUNCTION(EncMB_P));
+        m_kernelB = CreateKernel(m_device, m_program, "EncMB_B", CM_KERNEL_FUNCTION(EncMB_B));
+#else
         m_kernelI = CreateKernel(m_device, m_program, "EncMB_I", (void *)EncMB_I);
         m_kernelP = CreateKernel(m_device, m_program, "EncMB_P", (void *)EncMB_P);
         m_kernelB = CreateKernel(m_device, m_program, "EncMB_B", (void *)EncMB_B);
+#endif
     }
 
     if (m_programHist)
     {
+#ifdef ANDROID
+        m_kernelHistFrame = CreateKernel(m_device, m_programHist, "HistogramSLMFrame", CM_KERNEL_FUNCTION(HistogramFrame));
+        m_kernelHistFields = CreateKernel(m_device, m_programHist, "HistogramSLMFields", CM_KERNEL_FUNCTION(HistogramFields));
+#else
         m_kernelHistFrame = CreateKernel(m_device, m_programHist, "HistogramSLMFrame", (void *)HistogramFrame);
         m_kernelHistFields = CreateKernel(m_device, m_programHist, "HistogramSLMFields", (void *)HistogramFields);
+#endif
     }
     m_nullBuf.Reset(m_device, 4);
 

--- a/_studio/shared/Android.mk
+++ b/_studio/shared/Android.mk
@@ -1,0 +1,3 @@
+# Recursively call sub-folder Android.mk
+
+include $(call all-subdir-makefiles)

--- a/_studio/shared/asc/Android.mk
+++ b/_studio/shared/asc/Android.mk
@@ -1,0 +1,97 @@
+LOCAL_PATH:= $(call my-dir)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(addprefix src/, asc_avx2_impl.cpp)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_INCLUDES_INTERNAL_HW) \
+    $(MFX_HOME)/_studio/mfx_lib/cmrt_cross_platform/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/asc/isa
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -mavx2 \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS += -I $(MFX_HOME)/_studio/shared/asc/include/
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_asc_avx2
+include $(BUILD_STATIC_LIBRARY)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(addprefix src/, asc_sse4_impl.cpp)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_INCLUDES_INTERNAL_HW) \
+    $(MFX_HOME)/_studio/mfx_lib/cmrt_cross_platform/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/asc/isa
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -msse4.1 \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_asc_sse4
+include $(BUILD_STATIC_LIBRARY)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+ASC_SRC_FILES := $(addprefix src/, \
+	asc.cpp \
+	asc_c_impl.cpp \
+	iofunctions.cpp \
+	motion_estimation_engine.cpp \
+	tree.cpp)
+
+LOCAL_SRC_FILES := $(ASC_SRC_FILES)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_INCLUDES_INTERNAL_HW) \
+    $(MFX_HOME)/_studio/mfx_lib/cmrt_cross_platform/include \
+    $(MFX_HOME)/_studio/mfx_lib/ext/genx/asc/isa
+
+LOCAL_STATIC_LIBRARIES := \
+	libmfx_asc_avx2 \
+	libmfx_asc_sse4
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -msse4.1 \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+LOCAL_WHOLE_STATIC_LIBRARIES := $(LOCAL_STATIC_LIBRARIES)
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_asc
+
+include $(BUILD_STATIC_LIBRARY)

--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -28,9 +28,15 @@
 #undef  UMC_VA_LINUX
 #define UMC_VA_LINUX
 
-// mfx_features.h is auto-generated file containing mediasdk per-component
-// enable defines
-#include "mfx_features.h"
+#if defined(ANDROID)
+    // we don't support config auto-generation on Android and have hardcoded
+    // definition instead
+    #include "mfx_android_defs.h"
+#else
+    // mfxconfig.h is auto-generated file containing mediasdk per-component
+    // enable defines
+    #include "mfx_features.h"
+#endif
 
 #define SYNCHRONIZATION_BY_VA_MAP_BUFFER
 #if !defined(SYNCHRONIZATION_BY_VA_SYNC_SURFACE)

--- a/_studio/shared/mfx_logging/Android.mk
+++ b/_studio/shared/mfx_logging/Android.mk
@@ -1,0 +1,26 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(addprefix src/, $(notdir $(wildcard $(LOCAL_PATH)/src/*.cpp)))
+
+LOCAL_C_INCLUDES := \
+    $(MFX_INCLUDES_INTERNAL_HW) \
+    $(MFX_HOME)/api/mediasdk_structures
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_logging
+
+include $(BUILD_STATIC_LIBRARY)
+

--- a/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp
+++ b/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp
@@ -71,6 +71,11 @@ std::map<uint64_t, std::vector<uint32_t>> AutoPerfUtility::tid2taskIds;
 
 void AutoPerfUtility::SetTaskId(uint32_t id)
 {
+    if (!g_perfutility->dwPerfUtilityIsEnabled)
+    {
+        return;
+    }
+
     uint64_t tid = pthread_self();
 
     decltype(tid2taskIds)::iterator it;

--- a/_studio/shared/mfx_trace/Android.mk
+++ b/_studio/shared/mfx_trace/Android.mk
@@ -1,0 +1,25 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(addprefix src/, $(notdir $(wildcard $(LOCAL_PATH)/src/*.cpp)))
+
+LOCAL_C_INCLUDES := \
+    $(MFX_INCLUDES_INTERNAL_HW) \
+    $(MFX_HOME)/api/mediasdk_structures
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libmfx_gen_trace
+
+include $(BUILD_STATIC_LIBRARY)

--- a/_studio/shared/mfx_trace/src/mfx_trace.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace.cpp
@@ -263,7 +263,7 @@ mfxTraceU32 mfx_trace_get_category_index(mfxTraceChar* category, mfxTraceU32& in
 
 inline bool MFXTrace_IsPrintableCategoryAndLevel(mfxTraceU32 m_OutputInitilized, mfxTraceU32 level)
 {
-    bool logFlag = false;
+    bool logFlag = true;
     if (m_OutputInitilized == MFX_TRACE_OUTPUT_TEXTLOG) {
 #ifndef NDEBUG
         if (g_Level == MFX_TXTLOG_LEVEL_MAX)

--- a/_studio/shared/mfx_trace/src/mfx_trace_textlog.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace_textlog.cpp
@@ -25,7 +25,7 @@
 extern "C"
 {
 
-#define MFT_TRACE_PATH_TO_TEMP_LIBLOG MFX_TRACE_STRING("/tmp/mfxlib.log")
+#define MFT_TRACE_PATH_TO_TEMP_LIBLOG MFX_TRACE_STRING("/data/local/tmp/mfx-gen.log")
 
 #include <stdio.h>
 #include "mfx_trace_utils.h"
@@ -85,8 +85,8 @@ mfxTraceU32 MFXTraceTextLog_Init()
     sts = MFXTraceTextLog_Close();
     if (!sts) sts = MFXTraceTextLog_GetRegistryParams();
 
-    std::string filename_path = "/tmp/mfxlib_Pid" + std::to_string(getpid()) + "_Tid" + std::to_string(pthread_self()) + ".log";
-    strcpy(g_mfxTracePrintfFileName,filename_path.c_str()); 
+    //std::string filename_path = "/tmp/mfxlib_Pid" + std::to_string(getpid()) + "_Tid" + std::to_string(pthread_self()) + ".log";
+    //strcpy(g_mfxTracePrintfFileName,filename_path.c_str()); 
 
     if (!sts)
     {

--- a/_studio/shared/mfx_trace/src/mfx_trace_utils_linux.cpp
+++ b/_studio/shared/mfx_trace/src/mfx_trace_utils_linux.cpp
@@ -74,7 +74,7 @@ FILE* mfx_trace_open_conf_file(const char* name)
     std::stringstream ss;
 
 #if defined(ANDROID)
-    const char* home = "/data/data/com.intel.vtune/mediasdk";
+    const char* home = "/data/local";
 #else
     const char* home = getenv("HOME");
 #endif

--- a/_studio/shared/umc/Android.mk
+++ b/_studio/shared/umc/Android.mk
@@ -1,0 +1,3 @@
+# Recursively call sub-folder Android.mk
+
+include $(call all-subdir-makefiles)

--- a/_studio/shared/umc/codec/Android.mk
+++ b/_studio/shared/umc/codec/Android.mk
@@ -1,0 +1,86 @@
+LOCAL_PATH:= $(call my-dir)
+
+# Setting subdirectories to march thru
+MFX_CODEC_LOCAL_DIRS := \
+    vc1_common \
+    jpeg_common \
+    color_space_converter \
+    mpeg2_dec \
+    h265_dec \
+    h264_dec \
+    vc1_dec \
+    jpeg_dec \
+    vp9_dec \
+    av1_dec
+
+MFX_CODEC_LOCAL_SRC_FILES := \
+  $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_CODEC_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/$(dir)/src/*.cpp)))
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := \
+    brc/src/umc_brc.cpp \
+    brc/src/umc_h264_brc.cpp \
+    brc/src/umc_mpeg2_brc.cpp \
+    brc/src/umc_video_brc.cpp
+
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/brc/include \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter \
+    -Wno-deprecated-declarations
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+LOCAL_SHARED_LIBRARIES := liblog libcutils
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libumc_brc
+
+include $(BUILD_STATIC_LIBRARY)
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(MFX_CODEC_LOCAL_SRC_FILES)
+
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/av1_dec/include \
+    $(LOCAL_PATH)/color_space_converter/include \
+    $(LOCAL_PATH)/h264_dec/include \
+    $(LOCAL_PATH)/h265_dec/include \
+    $(LOCAL_PATH)/jpeg_common/include \
+    $(LOCAL_PATH)/jpeg_dec/include \
+    $(LOCAL_PATH)/mpeg2_dec/include \
+    $(LOCAL_PATH)/vc1_common/include \
+    $(LOCAL_PATH)/vc1_dec/include \
+    $(LOCAL_PATH)/vp9_dec/include \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_SHARED_LIBRARIES := liblog libcutils
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libumc_codecs_hw
+
+include $(BUILD_STATIC_LIBRARY)

--- a/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
+++ b/_studio/shared/umc/codec/av1_dec/include/umc_av1_dec_defs.h
@@ -104,6 +104,7 @@ namespace UMC_AV1_DECODER
 
     enum AV1_OBU_TYPE
     {
+	OBU_Reserved = 0,
         OBU_SEQUENCE_HEADER = 1,
         OBU_TEMPORAL_DELIMITER = 2,
         OBU_FRAME_HEADER = 3,

--- a/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
+++ b/_studio/shared/umc/codec/av1_dec/src/umc_av1_bitstream.cpp
@@ -1211,7 +1211,8 @@ namespace UMC_AV1_DECODER
 
         if (info.header.obu_has_size_field)
             av1_read_obu_size(*this, obu_size, sizeFieldLength);
-        else if (info.header.obu_type != OBU_TEMPORAL_DELIMITER)
+	// Av1-spec section 6.2.2: Reserved units are for future use and shall be ignored by AV1 decoder.
+        else if (info.header.obu_type != OBU_TEMPORAL_DELIMITER && info.header.obu_type != OBU_Reserved)
             throw av1_exception(UMC::UMC_ERR_NOT_IMPLEMENTED); // no support for OBUs w/o size field so far
 
         info.size = headerSize + sizeFieldLength + obu_size;

--- a/_studio/shared/umc/core/Android.mk
+++ b/_studio/shared/umc/core/Android.mk
@@ -1,0 +1,41 @@
+LOCAL_PATH:= $(call my-dir)
+
+# Setting subdirectories to march thru
+MFX_LOCAL_DIRS := \
+    vm \
+    vm_plus \
+    umc
+
+MFX_LOCAL_SRC_FILES := \
+    $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/$(dir)/src/*.c))) \
+    $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/$(dir)/src/*.cpp)))
+
+MFX_LOCAL_INCLUDES := \
+    $(foreach dir, $(MFX_LOCAL_DIRS), $(wildcard $(LOCAL_PATH)/$(dir)/include))
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(MFX_LOCAL_SRC_FILES)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_LOCAL_INCLUDES) \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+LOCAL_STATIC_LIBRARIES += libmfx_logging
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libumc_core_hw
+
+include $(BUILD_STATIC_LIBRARY)

--- a/_studio/shared/umc/io/Android.mk
+++ b/_studio/shared/umc/io/Android.mk
@@ -1,0 +1,37 @@
+LOCAL_PATH:= $(call my-dir)
+
+MFX_LOCAL_DIRS_HW := \
+    umc_va
+
+MFX_LOCAL_SRC_FILES_HW := \
+  $(patsubst $(LOCAL_PATH)/%, %, $(foreach dir, $(MFX_LOCAL_DIRS_HW), $(wildcard $(LOCAL_PATH)/$(dir)/src/*.cpp)))
+
+MFX_LOCAL_INCLUDES_HW := \
+  $(foreach dir, $(MFX_LOCAL_DIRS_HW), $(wildcard $(LOCAL_PATH)/$(dir)/include))
+
+# =============================================================================
+
+include $(CLEAR_VARS)
+include $(MFX_HOME)/android/mfx_defs.mk
+
+LOCAL_SRC_FILES := $(MFX_LOCAL_SRC_FILES_HW)
+
+LOCAL_C_INCLUDES := \
+    $(MFX_LOCAL_INCLUDES_HW) \
+    $(MFX_INCLUDES_INTERNAL_HW)
+
+LOCAL_CFLAGS := \
+    $(MFX_CFLAGS_INTERNAL_HW) \
+    -Wno-error \
+    -Wno-unused-parameter \
+    -Wno-implicit-fallthrough
+
+LOCAL_CFLAGS_32 := $(MFX_CFLAGS_INTERNAL_32)
+LOCAL_CFLAGS_64 := $(MFX_CFLAGS_INTERNAL_64)
+
+LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE := libumc_va
+
+include $(BUILD_STATIC_LIBRARY)

--- a/android/Android.bp
+++ b/android/Android.bp
@@ -1,0 +1,10 @@
+
+cc_library_headers {
+
+    name: "libmfx_android_headers",
+    export_include_dirs: [
+        "include",
+    ],
+
+    vendor: true,
+}

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libmfx_gen_headers
+LOCAL_EXPORT_C_INCLUDE_DIRS :=  \
+    $(MFX_HOME)/api/vpl \
+    $(MFX_HOME)/api/vpl/private \
+    $(MFX_HOME)/api/mediasdk_structures \
+    $(MFX_HOME)/android/include
+
+include $(BUILD_HEADER_LIBRARY)

--- a/android/include/mfx_android_config.h
+++ b/android/include/mfx_android_config.h
@@ -1,0 +1,24 @@
+/********************************************************************************
+
+INTEL CORPORATION PROPRIETARY INFORMATION
+This software is supplied under the terms of a license agreement or nondisclosure
+agreement with Intel Corporation and may not be copied or disclosed except in
+accordance with the terms of that agreement
+Copyright(c) 2011-2018 Intel Corporation. All Rights Reserved.
+
+*********************************************************************************/
+
+#ifndef __MFX_CONFIG_H__
+#define __MFX_CONFIG_H__
+
+/* Google versions of Android */
+#define MFX_O     0x06
+#define MFX_O_MR1 0x07
+#define MFX_P     0x08
+#define MFX_Q     0x09
+#define MFX_R     0x0a
+#define MFX_S     0x0b
+#define MFX_T     0x0c
+#define MFX_U     0x0d
+
+#endif // #ifndef __MFX_CONFIG_H__

--- a/android/include/mfx_android_defs.h
+++ b/android/include/mfx_android_defs.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2017-2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef __MFX_ANDROID_DEFS_H__
+#define __MFX_ANDROID_DEFS_H__
+
+  #define MFX_ENABLE_ASC
+  #define MFX_ENABLE_CPLIB
+
+  #define MFX_ENABLE_VPP
+
+  #define MFX_ENABLE_VC1_VIDEO_DECODE
+
+  #define MFX_ENABLE_H265_VIDEO_DECODE
+  #define MFX_ENABLE_H265_VIDEO_ENCODE
+
+  #define MFX_ENABLE_H264_VIDEO_DECODE
+  #define MFX_ENABLE_H264_VIDEO_ENCODE
+
+  #define MFX_ENABLE_MJPEG_VIDEO_DECODE
+  #define MFX_ENABLE_MJPEG_VIDEO_ENCODE
+
+  #define MFX_ENABLE_MPEG2_VIDEO_ENCODE
+  #define MFX_ENABLE_MPEG2_VIDEO_DECODE
+
+  #define MFX_ENABLE_VP8_VIDEO_DECODE
+
+  #define MFX_ENABLE_VP9_VIDEO_DECODE
+  #define MFX_ENABLE_VP9_VIDEO_ENCODE
+
+  #define MFX_ENABLE_AV1_VIDEO_DECODE
+  #define MFX_ENABLE_AV1_VIDEO_ENCODE
+
+  #define MFX_ENABLE_EXT
+
+#if MFX_ANDROID_VERSION >= MFX_P
+  #define MFX_ENABLE_KERNELS
+#endif
+
+#endif // #ifndef __MFX_ANDROID_DEFS_H__

--- a/android/mfx_defs.mk
+++ b/android/mfx_defs.mk
@@ -1,0 +1,114 @@
+# Purpose:
+#   Defines include paths, compilation flags, etc. to build Media SDK targets.
+#
+# Defined variables:
+#   MFX_CFLAGS - common flags for all targets
+#   MFX_CFLAGS_LIBVA - LibVA support flags (to build apps with or without LibVA support)
+#   MFX_INCLUDES - common include paths for all targets
+#   MFX_INCLUDES_LIBVA - include paths to LibVA headers
+#   MFX_LDFLAGS - common link flags for all targets
+
+# =============================================================================
+# Common definitions
+
+MFX_CFLAGS := -DANDROID
+
+#Media Version
+MEDIA_VERSION := 23.2.1
+MEDIA_VERSION_EXTRA := ""
+MEDIA_VERSION_ALL := $(MEDIA_VERSION).pre$(MEDIA_VERSION_EXTRA)
+
+MFX_CFLAGS += -DMEDIA_VERSION_STR=\"\\\"${MEDIA_VERSION}\\\"\"
+MFX_CFLAGS += -DONEVPL_EXPERIMENTAL
+
+# Android version preference:
+ifneq ($(filter 14 14.% U% ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_U
+endif
+ifneq ($(filter 13 13.% T% ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_T
+endif
+ifneq ($(filter 12 12.% S ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_S
+endif
+ifneq ($(filter 11 11.% R ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_R
+endif
+ifneq ($(filter 10 10.% Q ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_Q
+endif
+ifneq ($(filter 9 9.% P ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_P
+endif
+ifneq ($(filter 8.% O ,$(PLATFORM_VERSION)),)
+  ifneq ($(filter 8.0.%,$(PLATFORM_VERSION)),)
+    MFX_ANDROID_VERSION:= MFX_O
+  else
+    MFX_ANDROID_VERSION:= MFX_O_MR1
+  endif
+endif
+
+# Passing Android-dependency information to the code
+MFX_CFLAGS += \
+  -DMFX_ANDROID_VERSION=$(MFX_ANDROID_VERSION) \
+  -include mfx_android_config.h
+
+MFX_CFLAGS += \
+  -DMFX_VERSION=2009
+
+MFX_CFLAGS += \
+  -DMFX_FILE_VERSION=\"`echo $(MFX_VERSION) | cut -f 1 -d.``date +.%-y.%-m.%-d`\" \
+  -DMFX_PRODUCT_VERSION=\"$(MFX_VERSION)\"
+
+#  Security
+MFX_CFLAGS += \
+  -fstack-protector \
+  -fPIE -fPIC -pie \
+  -O2 -D_FORTIFY_SOURCE=2 \
+  -Wformat -Wformat-security \
+  -fexceptions -frtti -msse4.1 \
+  -Wno-non-virtual-dtor \
+  -mavx2
+
+# Enable feature with output decoded frames without latency regarding
+# SPS.VUI.max_num_reorder_frames
+ifeq ($(ENABLE_MAX_NUM_REORDER_FRAMES_OUTPUT),)
+    ENABLE_MAX_NUM_REORDER_FRAMES_OUTPUT:= true
+endif
+
+ifeq ($(ENABLE_MAX_NUM_REORDER_FRAMES_OUTPUT),true)
+  MFX_CFLAGS += -DENABLE_MAX_NUM_REORDER_FRAMES_OUTPUT
+endif
+
+# LibVA support.
+MFX_CFLAGS_LIBVA := -DLIBVA_SUPPORT -DLIBVA_ANDROID_SUPPORT
+
+ifneq ($(filter $(MFX_ANDROID_VERSION), MFX_O),)
+  MFX_CFLAGS_LIBVA += -DANDROID_O
+endif
+
+# Setting usual paths to include files
+MFX_INCLUDES := $(LOCAL_PATH)/include
+
+MFX_INCLUDES_LIBVA := $(TARGET_OUT_HEADERS)/libva
+
+# Setting usual link flags
+MFX_LDFLAGS := \
+  -z noexecstack \
+  -z relro -z now
+
+# Setting vendor
+LOCAL_MODULE_OWNER := intel
+
+# Moving executables to proprietary location
+LOCAL_PROPRIETARY_MODULE := true
+
+LOCAL_CPPFLAGS := -Wno-deprecated-declarations \
+	          -Wno-missing-field-initializers \
+		  -Wno-implicit-fallthrough
+
+
+# =============================================================================
+
+# Definitions specific to Media SDK internal things (do not apply for samples)
+include $(MFX_HOME)/android/mfx_defs_internal.mk

--- a/android/mfx_defs_internal.mk
+++ b/android/mfx_defs_internal.mk
@@ -1,0 +1,52 @@
+# Purpose:
+#   Defines include paths, compilation flags, etc. to build Media SDK
+# internal targets (libraries, test applications, etc.).
+#
+# Defined variables:
+#   MFX_CFLAGS_INTERNAL - all flags needed to build MFX targets
+#   MFX_CFLAGS_INTERNAL_HW - all flags needed to build MFX HW targets
+#   MFX_INCLUDES_INTERNAL - all include paths needed to build MFX targets
+#   MFX_INCLUDES_INTERNAL_HW - all include paths needed to build MFX HW targets
+
+MFX_CFLAGS_INTERNAL := $(MFX_CFLAGS)
+MFX_CFLAGS_INTERNAL_HW := \
+  $(MFX_CFLAGS_INTERNAL) \
+  -DMFX_VA \
+  -DMFX_ONEVPL \
+  -DMFX_VERSION_USE_LATEST \
+  -DMFX_DEPRECATED_OFF \
+  -DONEVPL_EXPERIMENTAL \
+  -DSYNCHRONIZATION_BY_VA_SYNC_SURFACE \
+  -D_FILE_OFFSET_BITS=64 \
+  -D__USE_LARGEFILE64 \
+  -DMFX_GIT_COMMIT=\"c6573984\" \
+  -DMFX_API_VERSION=\"2.9+\" \
+  -DNDEBUG \
+  -DMSDK_BUILD=\"\"
+
+MFX_CFLAGS_INTERNAL_32 := -DLINUX32
+MFX_CFLAGS_INTERNAL_64 := -DLINUX32 -DLINUX64
+
+MFX_INCLUDES_INTERNAL :=  \
+    $(MFX_INCLUDES) \
+    $(MFX_HOME)/_studio/shared/include \
+    $(MFX_HOME)/_studio/shared/umc/codec/av1_dec/include \
+    $(MFX_HOME)/_studio/shared/umc/codec/h265_dec/include \
+    $(MFX_HOME)/_studio/shared/umc/codec/h264_dec/include \
+    $(MFX_HOME)/_studio/shared/umc/codec/vp9_dec/include \
+    $(MFX_HOME)/_studio/shared/umc/core/umc/include \
+    $(MFX_HOME)/_studio/shared/umc/core/vm/include \
+    $(MFX_HOME)/_studio/shared/umc/core/vm_plus/include \
+    $(MFX_HOME)/_studio/shared/umc/io/umc_va/include \
+    $(MFX_HOME)/_studio/shared/mfx_logging/include \
+    $(MFX_HOME)/_studio/shared/mfx_trace/include \
+    $(MFX_HOME)/_studio/shared/mfx_trace/include/sys \
+    $(MFX_HOME)/_studio/mfx_lib/shared/include \
+    $(MFX_HOME)/_studio/shared/include \
+    $(MFX_HOME)/_studio/enctools/aenc/include \
+    $(MFX_HOME)/_studio/enctools/include \
+    $(MFX_HOME)/contrib/ipp/include
+
+MFX_INCLUDES_INTERNAL_HW := \
+    $(MFX_INCLUDES_INTERNAL) \
+    $(MFX_INCLUDES_LIBVA)


### PR DESCRIPTION
Share the way to enable logging on android.

1. apply this patch, build (`make libmfx-gen`) and replace it.
2. create a named ".mfx_trace" file in /data/local in android with the following content:
`Output=0x01`
3. make sure your program has permission to r/w in /data/local/tmp,
e.g. add root in hardware.intel.media.c2@1.0-service.rc
4. reboot android.
5. find the log file in /data/local/tmp/mfx-gen.log