### PR TITLE
[encode] Fix CTS fail of max B frames exceed expected number

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy.cpp
@@ -3452,7 +3452,7 @@ void SetDefaultGOP(
 
     if (pCO3)
     {
-        SetDefault<mfxU16>(pCO3->GPB, MFX_CODINGOPTION_ON);
+        SetDefault<mfxU16>(pCO3->GPB, MFX_CODINGOPTION_OFF);
 
         defPar.base.GetNumRefActive(
             defPar


### PR DESCRIPTION
Some CTS tests of android.videocodec.cts.VideoEncoderMaxBFrameTest# testMaxBFrameSupport failed with "Number of BFrames in a SubGOP exceeds maximum number of BFrames configured".

Cause is for HEVC encode, CO3->GPB is set to "on" by default, which makes GPB frames are used instead of P frames. In CTS test, GPB frames are considered B frames.

Solution is for HEVC encode, set default CO3->GPB to "off" to use P frames ont GPB frames.

Tracked-On:OAM-118626