### PR TITLE
[encode] Allow GPB set to off for HEVC encode

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_iddi_packer.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_iddi_packer.h
@@ -61,7 +61,7 @@ protected:
     void HardcodeCapsCommon(EncodeCapsHevc& caps, const mfxVideoParam& par)
     {
         caps.SliceIPOnly        = IsOn(par.mfx.LowPower);
-        caps.msdk.PSliceSupport = false;
+        caps.msdk.PSliceSupport = true;
     }
 };
 


### PR DESCRIPTION
Some CTS tests of android.videocodec.cts.VideoEncoderMaxBFrameTest# testMaxBFrameSupport failed with "Number of BFrames in a SubGOP exceeds maximum number of BFrames configured".

Cause is for HEVC encode, CO3->GPB is set to "on" by default, which makes GPB frames are used instead of P frames. In CTS test, GPB frames are considered B frames.

Solution is for HEVC encode, set CO3->GPB to "off" in mediasdk_c2 to use P frames not GPB frames. But in onevpl-intel-gpu, HEVC encode caps did not enable "GPB off" before, change HEVC encode caps to enable it.

Tracked-On: OAM-118626