### PR TITLE
Fix Cts avc profile level test

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_enc_common_hw.cpp
@@ -3056,7 +3056,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
                     par.mfx.CodecLevel = GetMaxSupportedLevel();
             }
         }
-        else if (par.mfx.CodecLevel != 0 && par.mfx.CodecLevel < minLevel)
+        else if (par.mfx.CodecLevel != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
         {
             if (extBits->SPSBuffer)
                 MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3086,7 +3086,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
                     par.mfx.CodecLevel = GetMaxSupportedLevel();
             }
         }
-        else if (par.mfx.CodecLevel != 0 && par.mfx.CodecLevel < minLevel)
+        else if (par.mfx.CodecLevel != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
         {
             if (extBits->SPSBuffer)
                 MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3110,7 +3110,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
             par.mfx.CodecLevel = MFX_LEVEL_AVC_52;
             par.mfx.NumRefFrame = GetMaxNumRefFrame(par);
         }
-        else if (par.mfx.CodecLevel != 0 && par.mfx.CodecLevel < minLevel)
+        else if (par.mfx.CodecLevel != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
         {
             if (extBits->SPSBuffer)
                 MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3482,7 +3482,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
                 {
                     if (mfxU16 minLevel = GetLevelLimitByMaxBitrate(profile, par.calcParam.targetKbps))
                     {
-                        if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                        if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                         {
                             if (extBits->SPSBuffer)
                                 MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3554,7 +3554,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
             {
                 if (mfxU16 minLevel = GetLevelLimitByMaxBitrate(profile, par.calcParam.maxKbps))
                 {
-                    if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                    if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                     {
                         if (extBits->SPSBuffer)
                             MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3644,7 +3644,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
                 {
                     if (mfxU16 minLevel = GetLevelLimitByBufferSize(profile, par.calcParam.bufferSizeInKB))
                     {
-                        if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                        if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                         {
                             if (extBits->SPSBuffer)
                                 MFX_RETURN(Error(MFX_ERR_INCOMPATIBLE_VIDEO_PARAM));
@@ -3698,7 +3698,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         {
             if (mfxU16 minLevel = GetLevelLimitByMaxBitrate(profile, par.calcParam.decorativeHrdParam.targetKbps))
             {
-                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                 {
                     changed = true;
                     par.mfx.CodecLevel   = minLevel;
@@ -3728,7 +3728,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         {
             if (mfxU16 minLevel = GetLevelLimitByMaxBitrate(profile, par.calcParam.decorativeHrdParam.maxKbps))
             {
-                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                 {
                     changed = true;
                     par.mfx.CodecLevel = minLevel;
@@ -3752,7 +3752,7 @@ mfxStatus MfxHwH264Encode::CheckVideoParamQueryLike(
         {
             if (mfxU16 minLevel = GetLevelLimitByBufferSize(profile, par.calcParam.decorativeHrdParam.bufferSizeInKB))
             {
-                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && par.mfx.CodecLevel < minLevel)
+                if (par.mfx.CodecLevel != 0 && par.mfx.CodecProfile != 0 && (par.mfx.CodecLevel != MFX_LEVEL_AVC_1b || minLevel != MFX_LEVEL_AVC_1) && par.mfx.CodecLevel < minLevel)
                 {
                     changed = true;
                     par.mfx.CodecLevel = minLevel;


### PR DESCRIPTION
Value: MFX_LEVEL_AVC_1:10 MFX_LEVEL_AVC_1b:9
The functions `GetLevelLimitByDpbSize()`, `GetLevelLimitByFrameSize()`, `GetLevelLimitByMbps()`, and `GetLevelLimitByMaxBitrate()` return the minimum level according to the frame size, FPS and profile. Since the capability of level MFX_LEVEL_AVC_1b is greater than level MFX_LEVEL_AVC_1, the CodecLevel should not be updated in this case.

Cases:
1.android.media.recorder.cts.MediaRecorderTest#testProfileAvcBaselineLevel1 2.android.mediav2.cts.EncoderProfileLevelTest#testValidateProfileLevel [8_c2.intel.avc.encoder_video/avc_128kbps_176x144_15fps_yuv420flexible_2_0-bframes] 3.android.mediav2.cts.EncoderProfileLevelTest#testValidateProfileLevel [10_c2.intel.avc.encoder_video/avc_128kbps_176x144_15fps_yuv420flexible_2_2-bframes]

Tracked-On: OAM-119037